### PR TITLE
Fix pytrousse dependency with git method

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ install_requires = [
     "numba",
     "hdbscan",
     "umap-learn",
-    "pytrousse @ https://github.com/HK3-Lab-Team/pytrousse/tarball/stable#egg=pytrousse",
+    "pytrousse @ git+git://github.com/HK3-Lab-Team/pytrousse@stable#egg=pytrousse",
 ]
 test_requires = ["pytest", "coverage", "pytest-cov", "coveralls"]
 


### PR DESCRIPTION
This makes the requirement coherent with the other private packages reference_interval and smvet